### PR TITLE
log -> logrus

### DIFF
--- a/google/batcher.go
+++ b/google/batcher.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sync"
 	"time"
 

--- a/google/batcher_test.go
+++ b/google/batcher_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"sync"
 	"testing"

--- a/google/bootstrap_utils_test.go
+++ b/google/bootstrap_utils_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 	"testing"

--- a/google/cloud_identity_group_membership_utils.go
+++ b/google/cloud_identity_group_membership_utils.go
@@ -1,7 +1,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/errwrap"

--- a/google/cloudrun_polling.go
+++ b/google/cloudrun_polling.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/errwrap"
 )

--- a/google/common_diff_suppress.go
+++ b/google/common_diff_suppress.go
@@ -5,7 +5,7 @@ package google
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"reflect"
 	"regexp"

--- a/google/common_operation.go
+++ b/google/common_operation.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/google/common_polling.go
+++ b/google/common_polling.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sync"
 	"time"
 

--- a/google/compute_operation.go
+++ b/google/compute_operation.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"google.golang.org/api/compute/v1"

--- a/google/config.go
+++ b/google/config.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"regexp"
 	"strconv"

--- a/google/container_operation.go
+++ b/google/container_operation.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"google.golang.org/api/container/v1"

--- a/google/data_source_cloud_run_locations.go
+++ b/google/data_source_cloud_run_locations.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/data_source_google_composer_image_versions.go
+++ b/google/data_source_google_composer_image_versions.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/google/data_source_google_compute_image.go
+++ b/google/data_source_google_compute_image.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/data_source_google_compute_node_types.go
+++ b/google/data_source_google_compute_node_types.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/data_source_google_compute_region_instance_group.go
+++ b/google/data_source_google_compute_region_instance_group.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/google/data_source_google_compute_regions.go
+++ b/google/data_source_google_compute_regions.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/data_source_google_compute_zones.go
+++ b/google/data_source_google_compute_zones.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sort"
 	"strings"
 

--- a/google/data_source_google_kms_crypto_key_version.go
+++ b/google/data_source_google_kms_crypto_key_version.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/data_source_google_kms_secret.go
+++ b/google/data_source_google_kms_secret.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 func dataSourceGoogleKmsSecret() *schema.Resource {

--- a/google/data_source_google_kms_secret_ciphertext.go
+++ b/google/data_source_google_kms_secret_ciphertext.go
@@ -5,7 +5,7 @@ import (
 
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/google/data_source_google_kms_secret_test.go
+++ b/google/data_source_google_kms_secret_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/google/data_source_google_service_account_access_token.go
+++ b/google/data_source_google_service_account_access_token.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"strings"
 

--- a/google/data_source_google_sql_ca_certs.go
+++ b/google/data_source_google_sql_ca_certs.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/google/data_source_google_storage_bucket.go
+++ b/google/data_source_google_storage_bucket.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 func dataSourceGoogleStorageBucket() *schema.Resource {

--- a/google/data_source_secret_manager_secret_version.go
+++ b/google/data_source_secret_manager_secret_version.go
@@ -3,7 +3,7 @@ package google
 import (
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/data_source_secret_manager_secret_version_access.go
+++ b/google/data_source_secret_manager_secret_version_access.go
@@ -3,7 +3,7 @@ package google
 import (
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/data_source_storage_object_signed_url.go
+++ b/google/data_source_storage_object_signed_url.go
@@ -11,7 +11,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/url"
 	"os"
 	"sort"

--- a/google/data_source_tpu_tensorflow_versions.go
+++ b/google/data_source_tpu_tensorflow_versions.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/dcl_logger.go
+++ b/google/dcl_logger.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 type dclLogger struct{}

--- a/google/error_retry_predicates.go
+++ b/google/error_retry_predicates.go
@@ -3,7 +3,7 @@ package google
 import (
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"net/url"
 	"regexp"

--- a/google/framework_provider_test.go
+++ b/google/framework_provider_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"os"
 	"path/filepath"

--- a/google/iam.go
+++ b/google/iam.go
@@ -4,7 +4,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"sort"
 	"strings"

--- a/google/import.go
+++ b/google/import.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strconv"
 	"strings"

--- a/google/metadata.go
+++ b/google/metadata.go
@@ -3,7 +3,7 @@ package google
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sort"
 
 	"google.golang.org/api/compute/v1"

--- a/google/mutexkv.go
+++ b/google/mutexkv.go
@@ -1,7 +1,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sync"
 )
 

--- a/google/privateca_ca_utils.go
+++ b/google/privateca_ca_utils.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math/rand"
 	"regexp"
 	"time"

--- a/google/provider_test.go
+++ b/google/provider_test.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math/rand"
 	"net/http"
 	"os"

--- a/google/resource_access_approval_folder_settings_test.go
+++ b/google/resource_access_approval_folder_settings_test.go
@@ -1,7 +1,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_access_approval_organization_settings_test.go
+++ b/google/resource_access_approval_organization_settings_test.go
@@ -1,7 +1,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_access_approval_project_settings_test.go
+++ b/google/resource_access_approval_project_settings_test.go
@@ -1,7 +1,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_access_context_manager_access_level.go
+++ b/google/resource_access_context_manager_access_level.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_access_context_manager_access_level_condition.go
+++ b/google/resource_access_context_manager_access_level_condition.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_access_context_manager_access_levels.go
+++ b/google/resource_access_context_manager_access_levels.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_access_context_manager_access_policy.go
+++ b/google/resource_access_context_manager_access_policy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_access_context_manager_access_policy_test.go
+++ b/google/resource_access_context_manager_access_policy_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	neturl "net/url"
 	"testing"
 

--- a/google/resource_access_context_manager_gcp_user_access_binding.go
+++ b/google/resource_access_context_manager_gcp_user_access_binding.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_access_context_manager_gcp_user_access_binding_sweeper_test.go
+++ b/google/resource_access_context_manager_gcp_user_access_binding_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_access_context_manager_service_perimeter.go
+++ b/google/resource_access_context_manager_service_perimeter.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_access_context_manager_service_perimeter_resource.go
+++ b/google/resource_access_context_manager_service_perimeter_resource.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_access_context_manager_service_perimeters.go
+++ b/google/resource_access_context_manager_service_perimeters.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_active_directory_domain.go
+++ b/google/resource_active_directory_domain.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_active_directory_domain_sweeper_test.go
+++ b/google/resource_active_directory_domain_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_active_directory_domain_trust.go
+++ b/google/resource_active_directory_domain_trust.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_alloydb_backup.go
+++ b/google/resource_alloydb_backup.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_alloydb_backup_sweeper_test.go
+++ b/google/resource_alloydb_backup_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_alloydb_cluster.go
+++ b/google/resource_alloydb_cluster.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_alloydb_cluster_sweeper_test.go
+++ b/google/resource_alloydb_cluster_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_alloydb_instance.go
+++ b/google/resource_alloydb_instance.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_alloydb_instance_sweeper_test.go
+++ b/google/resource_alloydb_instance_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_apigee_addons_config.go
+++ b/google/resource_apigee_addons_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_apigee_addons_config_sweeper_test.go
+++ b/google/resource_apigee_addons_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_apigee_endpoint_attachment.go
+++ b/google/resource_apigee_endpoint_attachment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_apigee_envgroup.go
+++ b/google/resource_apigee_envgroup.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_apigee_envgroup_attachment.go
+++ b/google/resource_apigee_envgroup_attachment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_apigee_envgroup_sweeper_test.go
+++ b/google/resource_apigee_envgroup_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_apigee_environment.go
+++ b/google/resource_apigee_environment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_apigee_environment_sweeper_test.go
+++ b/google/resource_apigee_environment_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_apigee_instance.go
+++ b/google/resource_apigee_instance.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_apigee_instance_attachment.go
+++ b/google/resource_apigee_instance_attachment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_apigee_instance_attachment_sweeper_test.go
+++ b/google/resource_apigee_instance_attachment_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_apigee_instance_sweeper_test.go
+++ b/google/resource_apigee_instance_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_apigee_nat_address.go
+++ b/google/resource_apigee_nat_address.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_apigee_organization.go
+++ b/google/resource_apigee_organization.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_apigee_organization_sweeper_test.go
+++ b/google/resource_apigee_organization_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_apigee_sync_authorization.go
+++ b/google/resource_apigee_sync_authorization.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_apikeys_key.go
+++ b/google/resource_apikeys_key.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_apikeys_key_sweeper_test.go
+++ b/google/resource_apikeys_key_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	apikeys "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/apikeys"

--- a/google/resource_app_engine_app_version_sweeper_test.go
+++ b/google/resource_app_engine_app_version_sweeper_test.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/google/resource_app_engine_application.go
+++ b/google/resource_app_engine_application.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"

--- a/google/resource_app_engine_application_url_dispatch_rules.go
+++ b/google/resource_app_engine_application_url_dispatch_rules.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_app_engine_application_url_dispatch_rules_generated_test.go
+++ b/google/resource_app_engine_application_url_dispatch_rules_generated_test.go
@@ -15,7 +15,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_app_engine_domain_mapping.go
+++ b/google/resource_app_engine_domain_mapping.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_app_engine_domain_mapping_sweeper_test.go
+++ b/google/resource_app_engine_domain_mapping_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_app_engine_firewall_rule.go
+++ b/google/resource_app_engine_firewall_rule.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_app_engine_flexible_app_version.go
+++ b/google/resource_app_engine_flexible_app_version.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_app_engine_flexible_app_version_generated_test.go
+++ b/google/resource_app_engine_flexible_app_version_generated_test.go
@@ -15,7 +15,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_app_engine_service_network_settings.go
+++ b/google/resource_app_engine_service_network_settings.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_app_engine_service_split_traffic.go
+++ b/google/resource_app_engine_service_split_traffic.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_app_engine_standard_app_version.go
+++ b/google/resource_app_engine_standard_app_version.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_app_engine_standard_app_version_generated_test.go
+++ b/google/resource_app_engine_standard_app_version_generated_test.go
@@ -15,7 +15,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_artifact_registry_repository.go
+++ b/google/resource_artifact_registry_repository.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_artifact_registry_repository_sweeper_test.go
+++ b/google/resource_artifact_registry_repository_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_assured_workloads_workload.go
+++ b/google/resource_assured_workloads_workload.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_beyondcorp_app_connection.go
+++ b/google/resource_beyondcorp_app_connection.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_beyondcorp_app_connection_sweeper_test.go
+++ b/google/resource_beyondcorp_app_connection_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_beyondcorp_app_connector.go
+++ b/google/resource_beyondcorp_app_connector.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_beyondcorp_app_connector_sweeper_test.go
+++ b/google/resource_beyondcorp_app_connector_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_beyondcorp_app_gateway.go
+++ b/google/resource_beyondcorp_app_gateway.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_beyondcorp_app_gateway_sweeper_test.go
+++ b/google/resource_beyondcorp_app_gateway_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_bigquery_analytics_hub_data_exchange.go
+++ b/google/resource_bigquery_analytics_hub_data_exchange.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_bigquery_analytics_hub_data_exchange_sweeper_test.go
+++ b/google/resource_bigquery_analytics_hub_data_exchange_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_bigquery_analytics_hub_listing.go
+++ b/google/resource_bigquery_analytics_hub_listing.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_bigquery_analytics_hub_listing_sweeper_test.go
+++ b/google/resource_bigquery_analytics_hub_listing_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_bigquery_connection.go
+++ b/google/resource_bigquery_connection.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_bigquery_connection_sweeper_test.go
+++ b/google/resource_bigquery_connection_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_bigquery_data_transfer_config.go
+++ b/google/resource_bigquery_data_transfer_config.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_bigquery_data_transfer_config_sweeper_test.go
+++ b/google/resource_bigquery_data_transfer_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_bigquery_dataset.go
+++ b/google/resource_bigquery_dataset.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"

--- a/google/resource_bigquery_dataset_access.go
+++ b/google/resource_bigquery_dataset_access.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_bigquery_job.go
+++ b/google/resource_bigquery_job.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"

--- a/google/resource_bigquery_reservation.go
+++ b/google/resource_bigquery_reservation.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_bigquery_reservation_assignment.go
+++ b/google/resource_bigquery_reservation_assignment.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_bigquery_reservation_sweeper_test.go
+++ b/google/resource_bigquery_reservation_sweeper_test.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/google/resource_bigquery_routine.go
+++ b/google/resource_bigquery_routine.go
@@ -17,7 +17,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_bigquery_routine_sweeper_test.go
+++ b/google/resource_bigquery_routine_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_bigquery_table.go
+++ b/google/resource_bigquery_table.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"sort"

--- a/google/resource_bigtable_app_profile.go
+++ b/google/resource_bigtable_app_profile.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_bigtable_gc_policy.go
+++ b/google/resource_bigtable_gc_policy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google/resource_bigtable_instance.go
+++ b/google/resource_bigtable_instance.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_bigtable_instance_migrate.go
+++ b/google/resource_bigtable_instance_migrate.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/google/resource_bigtable_instance_sweeper_test.go
+++ b/google/resource_bigtable_instance_sweeper_test.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/google/resource_bigtable_table.go
+++ b/google/resource_bigtable_table.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"cloud.google.com/go/bigtable"

--- a/google/resource_billing_budget.go
+++ b/google/resource_billing_budget.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_billing_budget_sweeper_test.go
+++ b/google/resource_billing_budget_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_binary_authorization_attestor.go
+++ b/google/resource_binary_authorization_attestor.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"

--- a/google/resource_binary_authorization_attestor_sweeper_test.go
+++ b/google/resource_binary_authorization_attestor_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_binary_authorization_policy.go
+++ b/google/resource_binary_authorization_policy.go
@@ -17,7 +17,7 @@ package google
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"

--- a/google/resource_certificate_manager_certificate.go
+++ b/google/resource_certificate_manager_certificate.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_certificate_manager_certificate_map.go
+++ b/google/resource_certificate_manager_certificate_map.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_certificate_manager_certificate_map_entry.go
+++ b/google/resource_certificate_manager_certificate_map_entry.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_certificate_manager_certificate_map_entry_sweeper_test.go
+++ b/google/resource_certificate_manager_certificate_map_entry_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_certificate_manager_certificate_map_sweeper_test.go
+++ b/google/resource_certificate_manager_certificate_map_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_certificate_manager_certificate_sweeper_test.go
+++ b/google/resource_certificate_manager_certificate_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_certificate_manager_dns_authorization.go
+++ b/google/resource_certificate_manager_dns_authorization.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_certificate_manager_dns_authorization_sweeper_test.go
+++ b/google/resource_certificate_manager_dns_authorization_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_cloud_asset_folder_feed.go
+++ b/google/resource_cloud_asset_folder_feed.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_cloud_asset_folder_feed_sweeper_test.go
+++ b/google/resource_cloud_asset_folder_feed_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_cloud_asset_organization_feed.go
+++ b/google/resource_cloud_asset_organization_feed.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_cloud_asset_organization_feed_sweeper_test.go
+++ b/google/resource_cloud_asset_organization_feed_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_cloud_asset_project_feed.go
+++ b/google/resource_cloud_asset_project_feed.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_cloud_asset_project_feed_sweeper_test.go
+++ b/google/resource_cloud_asset_project_feed_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_cloud_identity_group.go
+++ b/google/resource_cloud_identity_group.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_cloud_identity_group_membership.go
+++ b/google/resource_cloud_identity_group_membership.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"

--- a/google/resource_cloud_identity_group_sweeper_test.go
+++ b/google/resource_cloud_identity_group_sweeper_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/url"
 	"testing"
 

--- a/google/resource_cloud_ids_endpoint.go
+++ b/google/resource_cloud_ids_endpoint.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_cloud_run_domain_mapping.go
+++ b/google/resource_cloud_run_domain_mapping.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_cloud_run_domain_mapping_sweeper_test.go
+++ b/google/resource_cloud_run_domain_mapping_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_cloud_run_service.go
+++ b/google/resource_cloud_run_service.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_cloud_run_service_sweeper_test.go
+++ b/google/resource_cloud_run_service_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_cloud_run_v2_job.go
+++ b/google/resource_cloud_run_v2_job.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_cloud_run_v2_job_sweeper_test.go
+++ b/google/resource_cloud_run_v2_job_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_cloud_run_v2_service.go
+++ b/google/resource_cloud_run_v2_service.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_cloud_run_v2_service_sweeper_test.go
+++ b/google/resource_cloud_run_v2_service_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_cloud_scheduler_job.go
+++ b/google/resource_cloud_scheduler_job.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_cloud_scheduler_job_sweeper_test.go
+++ b/google/resource_cloud_scheduler_job_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_cloud_tasks_queue.go
+++ b/google/resource_cloud_tasks_queue.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_cloud_tasks_queue_sweeper_test.go
+++ b/google/resource_cloud_tasks_queue_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_cloudbuild_trigger.go
+++ b/google/resource_cloudbuild_trigger.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_cloudbuild_trigger_sweeper_test.go
+++ b/google/resource_cloudbuild_trigger_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_cloudbuild_worker_pool.go
+++ b/google/resource_cloudbuild_worker_pool.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_cloudbuild_worker_pool_sweeper_test.go
+++ b/google/resource_cloudbuild_worker_pool_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	cloudbuild "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/cloudbuild"

--- a/google/resource_clouddeploy_delivery_pipeline.go
+++ b/google/resource_clouddeploy_delivery_pipeline.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_clouddeploy_delivery_pipeline_sweeper_test.go
+++ b/google/resource_clouddeploy_delivery_pipeline_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	clouddeploy "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/clouddeploy"

--- a/google/resource_clouddeploy_target.go
+++ b/google/resource_clouddeploy_target.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_clouddeploy_target_sweeper_test.go
+++ b/google/resource_clouddeploy_target_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	clouddeploy "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/clouddeploy"

--- a/google/resource_cloudfunctions2_function.go
+++ b/google/resource_cloudfunctions2_function.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_cloudfunctions2_function_sweeper_test.go
+++ b/google/resource_cloudfunctions2_function_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_cloudfunctions_function.go
+++ b/google/resource_cloudfunctions_function.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/api/cloudfunctions/v1"
 
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/url"
 	"strconv"
 	"strings"

--- a/google/resource_cloudfunctions_function_test.go
+++ b/google/resource_cloudfunctions_function_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 	"testing"

--- a/google/resource_cloudiot_device.go
+++ b/google/resource_cloudiot_device.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_cloudiot_device_sweeper_test.go
+++ b/google/resource_cloudiot_device_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_cloudiot_registry.go
+++ b/google/resource_cloudiot_registry.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_cloudiot_registry_sweeper_test.go
+++ b/google/resource_cloudiot_registry_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_composer_environment.go
+++ b/google/resource_composer_environment.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strings"
 	"time"

--- a/google/resource_composer_environment_test.go
+++ b/google/resource_composer_environment_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strings"
 	"time"

--- a/google/resource_compute_address.go
+++ b/google/resource_compute_address.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_address_sweeper_test.go
+++ b/google/resource_compute_address_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_attached_disk.go
+++ b/google/resource_compute_attached_disk.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google/resource_compute_autoscaler.go
+++ b/google/resource_compute_autoscaler.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_autoscaler_sweeper_test.go
+++ b/google/resource_compute_autoscaler_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_backend_bucket.go
+++ b/google/resource_compute_backend_bucket.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_backend_bucket_signed_url_key.go
+++ b/google/resource_compute_backend_bucket_signed_url_key.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_backend_bucket_signed_url_key_sweeper_test.go
+++ b/google/resource_compute_backend_bucket_signed_url_key_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_backend_bucket_sweeper_test.go
+++ b/google/resource_compute_backend_bucket_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_backend_service.go
+++ b/google/resource_compute_backend_service.go
@@ -17,7 +17,7 @@ package google
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"

--- a/google/resource_compute_backend_service_signed_url_key.go
+++ b/google/resource_compute_backend_service_signed_url_key.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_backend_service_signed_url_key_sweeper_test.go
+++ b/google/resource_compute_backend_service_signed_url_key_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_backend_service_sweeper_test.go
+++ b/google/resource_compute_backend_service_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_disk.go
+++ b/google/resource_compute_disk.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_compute_disk_resource_policy_attachment.go
+++ b/google/resource_compute_disk_resource_policy_attachment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_disk_sweeper_test.go
+++ b/google/resource_compute_disk_sweeper_test.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/google/resource_compute_external_vpn_gateway.go
+++ b/google/resource_compute_external_vpn_gateway.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_external_vpn_gateway_sweeper_test.go
+++ b/google/resource_compute_external_vpn_gateway_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_firewall.go
+++ b/google/resource_compute_firewall.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"sort"
 	"strings"

--- a/google/resource_compute_firewall_migrate.go
+++ b/google/resource_compute_firewall_migrate.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sort"
 	"strconv"
 	"strings"

--- a/google/resource_compute_firewall_policy.go
+++ b/google/resource_compute_firewall_policy.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_compute_firewall_policy_association.go
+++ b/google/resource_compute_firewall_policy_association.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_compute_firewall_policy_rule.go
+++ b/google/resource_compute_firewall_policy_rule.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_compute_firewall_sweeper_test.go
+++ b/google/resource_compute_firewall_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_forwarding_rule.go
+++ b/google/resource_compute_forwarding_rule.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_compute_forwarding_rule_sweeper_test.go
+++ b/google/resource_compute_forwarding_rule_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	compute "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/compute"

--- a/google/resource_compute_global_address.go
+++ b/google/resource_compute_global_address.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_global_address_sweeper_test.go
+++ b/google/resource_compute_global_address_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_global_forwarding_rule.go
+++ b/google/resource_compute_global_forwarding_rule.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_compute_global_forwarding_rule_sweeper_test.go
+++ b/google/resource_compute_global_forwarding_rule_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	compute "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/compute"

--- a/google/resource_compute_global_network_endpoint.go
+++ b/google/resource_compute_global_network_endpoint.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_global_network_endpoint_group.go
+++ b/google/resource_compute_global_network_endpoint_group.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_global_network_endpoint_group_sweeper_test.go
+++ b/google/resource_compute_global_network_endpoint_group_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_ha_vpn_gateway.go
+++ b/google/resource_compute_ha_vpn_gateway.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_ha_vpn_gateway_sweeper_test.go
+++ b/google/resource_compute_ha_vpn_gateway_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_health_check.go
+++ b/google/resource_compute_health_check.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strconv"
 	"strings"

--- a/google/resource_compute_health_check_sweeper_test.go
+++ b/google/resource_compute_health_check_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_http_health_check.go
+++ b/google/resource_compute_http_health_check.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_http_health_check_sweeper_test.go
+++ b/google/resource_compute_http_health_check_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_https_health_check.go
+++ b/google/resource_compute_https_health_check.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_https_health_check_sweeper_test.go
+++ b/google/resource_compute_https_health_check_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_image.go
+++ b/google/resource_compute_image.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_compute_image_sweeper_test.go
+++ b/google/resource_compute_image_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_instance.go
+++ b/google/resource_compute_instance.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 	"time"

--- a/google/resource_compute_instance_from_template.go
+++ b/google/resource_compute_instance_from_template.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/google/resource_compute_instance_group.go
+++ b/google/resource_compute_instance_group.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google/resource_compute_instance_group_manager_test.go
+++ b/google/resource_compute_instance_group_manager_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/google/resource_compute_instance_group_migrate.go
+++ b/google/resource_compute_instance_group_migrate.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 

--- a/google/resource_compute_instance_group_named_port.go
+++ b/google/resource_compute_instance_group_named_port.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_instance_group_named_port_sweeper_test.go
+++ b/google/resource_compute_instance_group_named_port_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_instance_migrate.go
+++ b/google/resource_compute_instance_migrate.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 

--- a/google/resource_compute_instance_migrate_test.go
+++ b/google/resource_compute_instance_migrate_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 	"testing"

--- a/google/resource_compute_instance_template_migrate.go
+++ b/google/resource_compute_instance_template_migrate.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )

--- a/google/resource_compute_instance_template_sweeper_test.go
+++ b/google/resource_compute_instance_template_sweeper_test.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/google/resource_compute_instance_test.go
+++ b/google/resource_compute_instance_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"sort"
 	"strconv"

--- a/google/resource_compute_interconnect_attachment.go
+++ b/google/resource_compute_interconnect_attachment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_managed_ssl_certificate.go
+++ b/google/resource_compute_managed_ssl_certificate.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_managed_ssl_certificate_sweeper_test.go
+++ b/google/resource_compute_managed_ssl_certificate_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_network.go
+++ b/google/resource_compute_network.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_network_endpoint.go
+++ b/google/resource_compute_network_endpoint.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_network_endpoint_group.go
+++ b/google/resource_compute_network_endpoint_group.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_network_endpoint_group_sweeper_test.go
+++ b/google/resource_compute_network_endpoint_group_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_network_firewall_policy.go
+++ b/google/resource_compute_network_firewall_policy.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_compute_network_firewall_policy_association.go
+++ b/google/resource_compute_network_firewall_policy_association.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_compute_network_firewall_policy_rule.go
+++ b/google/resource_compute_network_firewall_policy_rule.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_compute_network_firewall_policy_sweeper_test.go
+++ b/google/resource_compute_network_firewall_policy_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	compute "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/compute"

--- a/google/resource_compute_network_peering.go
+++ b/google/resource_compute_network_peering.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sort"
 	"strings"
 	"time"

--- a/google/resource_compute_network_peering_routes_config.go
+++ b/google/resource_compute_network_peering_routes_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_network_sweeper_test.go
+++ b/google/resource_compute_network_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_node_group.go
+++ b/google/resource_compute_node_group.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"

--- a/google/resource_compute_node_group_sweeper_test.go
+++ b/google/resource_compute_node_group_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_node_template.go
+++ b/google/resource_compute_node_template.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_node_template_sweeper_test.go
+++ b/google/resource_compute_node_template_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_packet_mirroring.go
+++ b/google/resource_compute_packet_mirroring.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_packet_mirroring_sweeper_test.go
+++ b/google/resource_compute_packet_mirroring_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_per_instance_config.go
+++ b/google/resource_compute_per_instance_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_project_default_network_tier.go
+++ b/google/resource_compute_project_default_network_tier.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/google/resource_compute_project_metadata.go
+++ b/google/resource_compute_project_metadata.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_compute_project_metadata_item.go
+++ b/google/resource_compute_project_metadata_item.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_compute_region_autoscaler.go
+++ b/google/resource_compute_region_autoscaler.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_region_autoscaler_sweeper_test.go
+++ b/google/resource_compute_region_autoscaler_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_region_backend_service.go
+++ b/google/resource_compute_region_backend_service.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_region_backend_service_sweeper_test.go
+++ b/google/resource_compute_region_backend_service_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_region_disk.go
+++ b/google/resource_compute_region_disk.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_compute_region_disk_resource_policy_attachment.go
+++ b/google/resource_compute_region_disk_resource_policy_attachment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_region_health_check.go
+++ b/google/resource_compute_region_health_check.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_region_health_check_sweeper_test.go
+++ b/google/resource_compute_region_health_check_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_region_instance_group_manager.go
+++ b/google/resource_compute_region_instance_group_manager.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google/resource_compute_region_instance_group_manager_test.go
+++ b/google/resource_compute_region_instance_group_manager_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_region_network_endpoint_group.go
+++ b/google/resource_compute_region_network_endpoint_group.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_region_network_endpoint_group_sweeper_test.go
+++ b/google/resource_compute_region_network_endpoint_group_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_region_network_firewall_policy.go
+++ b/google/resource_compute_region_network_firewall_policy.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_compute_region_network_firewall_policy_association.go
+++ b/google/resource_compute_region_network_firewall_policy_association.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_compute_region_network_firewall_policy_rule.go
+++ b/google/resource_compute_region_network_firewall_policy_rule.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_compute_region_network_firewall_policy_sweeper_test.go
+++ b/google/resource_compute_region_network_firewall_policy_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	compute "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/compute"

--- a/google/resource_compute_region_per_instance_config.go
+++ b/google/resource_compute_region_per_instance_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_region_ssl_certificate.go
+++ b/google/resource_compute_region_ssl_certificate.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_region_ssl_certificate_sweeper_test.go
+++ b/google/resource_compute_region_ssl_certificate_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_region_target_http_proxy.go
+++ b/google/resource_compute_region_target_http_proxy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_region_target_http_proxy_sweeper_test.go
+++ b/google/resource_compute_region_target_http_proxy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_region_target_https_proxy.go
+++ b/google/resource_compute_region_target_https_proxy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_region_target_https_proxy_sweeper_test.go
+++ b/google/resource_compute_region_target_https_proxy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_region_target_tcp_proxy.go
+++ b/google/resource_compute_region_target_tcp_proxy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_region_target_tcp_proxy_sweeper_test.go
+++ b/google/resource_compute_region_target_tcp_proxy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_region_url_map.go
+++ b/google/resource_compute_region_url_map.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_region_url_map_sweeper_test.go
+++ b/google/resource_compute_region_url_map_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_reservation.go
+++ b/google/resource_compute_reservation.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/url"
 	"reflect"
 	"strconv"

--- a/google/resource_compute_reservation_sweeper_test.go
+++ b/google/resource_compute_reservation_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_resource_policy.go
+++ b/google/resource_compute_resource_policy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_resource_policy_sweeper_test.go
+++ b/google/resource_compute_resource_policy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_route.go
+++ b/google/resource_compute_route.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_route_sweeper_test.go
+++ b/google/resource_compute_route_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_router.go
+++ b/google/resource_compute_router.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_router_interface.go
+++ b/google/resource_compute_router_interface.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"strings"

--- a/google/resource_compute_router_nat.go
+++ b/google/resource_compute_router_nat.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_compute_router_nat_sweeper_test.go
+++ b/google/resource_compute_router_nat_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_router_peer.go
+++ b/google/resource_compute_router_peer.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strconv"
 	"strings"

--- a/google/resource_compute_router_peer_sweeper_test.go
+++ b/google/resource_compute_router_peer_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_router_sweeper_test.go
+++ b/google/resource_compute_router_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_security_policy.go
+++ b/google/resource_compute_security_policy.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"time"
 

--- a/google/resource_compute_service_attachment.go
+++ b/google/resource_compute_service_attachment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_service_attachment_sweeper_test.go
+++ b/google/resource_compute_service_attachment_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_shared_vpc_host_project.go
+++ b/google/resource_compute_shared_vpc_host_project.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_compute_shared_vpc_service_project.go
+++ b/google/resource_compute_shared_vpc_service_project.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google/resource_compute_snapshot.go
+++ b/google/resource_compute_snapshot.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_compute_snapshot_sweeper_test.go
+++ b/google/resource_compute_snapshot_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_ssl_certificate.go
+++ b/google/resource_compute_ssl_certificate.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_ssl_certificate_sweeper_test.go
+++ b/google/resource_compute_ssl_certificate_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_ssl_policy.go
+++ b/google/resource_compute_ssl_policy.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_ssl_policy_sweeper_test.go
+++ b/google/resource_compute_ssl_policy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_subnetwork.go
+++ b/google/resource_compute_subnetwork.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"reflect"
 	"time"

--- a/google/resource_compute_subnetwork_sweeper_test.go
+++ b/google/resource_compute_subnetwork_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_target_grpc_proxy.go
+++ b/google/resource_compute_target_grpc_proxy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_target_grpc_proxy_sweeper_test.go
+++ b/google/resource_compute_target_grpc_proxy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_target_http_proxy.go
+++ b/google/resource_compute_target_http_proxy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_target_http_proxy_sweeper_test.go
+++ b/google/resource_compute_target_http_proxy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_target_https_proxy.go
+++ b/google/resource_compute_target_https_proxy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_target_https_proxy_sweeper_test.go
+++ b/google/resource_compute_target_https_proxy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_target_instance.go
+++ b/google/resource_compute_target_instance.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_compute_target_instance_sweeper_test.go
+++ b/google/resource_compute_target_instance_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_target_pool.go
+++ b/google/resource_compute_target_pool.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strings"
 	"time"

--- a/google/resource_compute_target_ssl_proxy.go
+++ b/google/resource_compute_target_ssl_proxy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_target_ssl_proxy_sweeper_test.go
+++ b/google/resource_compute_target_ssl_proxy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_target_tcp_proxy.go
+++ b/google/resource_compute_target_tcp_proxy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_target_tcp_proxy_sweeper_test.go
+++ b/google/resource_compute_target_tcp_proxy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_url_map.go
+++ b/google/resource_compute_url_map.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_compute_url_map_sweeper_test.go
+++ b/google/resource_compute_url_map_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_vpn_gateway.go
+++ b/google/resource_compute_vpn_gateway.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_compute_vpn_gateway_sweeper_test.go
+++ b/google/resource_compute_vpn_gateway_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_compute_vpn_tunnel.go
+++ b/google/resource_compute_vpn_tunnel.go
@@ -17,7 +17,7 @@ package google
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net"
 	"reflect"
 	"strings"

--- a/google/resource_compute_vpn_tunnel_sweeper_test.go
+++ b/google/resource_compute_vpn_tunnel_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_container_analysis_note.go
+++ b/google/resource_container_analysis_note.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_container_analysis_note_sweeper_test.go
+++ b/google/resource_container_analysis_note_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_container_analysis_occurrence.go
+++ b/google/resource_container_analysis_occurrence.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_container_analysis_occurrence_sweeper_test.go
+++ b/google/resource_container_analysis_occurrence_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_container_attached_cluster.go
+++ b/google/resource_container_attached_cluster.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_container_aws_cluster.go
+++ b/google/resource_container_aws_cluster.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_container_aws_cluster_sweeper_test.go
+++ b/google/resource_container_aws_cluster_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	containeraws "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/containeraws"

--- a/google/resource_container_aws_node_pool.go
+++ b/google/resource_container_aws_node_pool.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_container_azure_client.go
+++ b/google/resource_container_azure_client.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_container_azure_client_sweeper_test.go
+++ b/google/resource_container_azure_client_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	containerazure "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/containerazure"

--- a/google/resource_container_azure_cluster.go
+++ b/google/resource_container_azure_cluster.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_container_azure_cluster_sweeper_test.go
+++ b/google/resource_container_azure_cluster_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	containerazure "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/containerazure"

--- a/google/resource_container_azure_node_pool.go
+++ b/google/resource_container_azure_node_pool.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_container_cluster.go
+++ b/google/resource_container_cluster.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_container_cluster_migrate.go
+++ b/google/resource_container_cluster_migrate.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 

--- a/google/resource_container_cluster_test.go
+++ b/google/resource_container_cluster_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strconv"
 	"testing"

--- a/google/resource_container_node_pool.go
+++ b/google/resource_container_node_pool.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strings"
 	"time"

--- a/google/resource_container_node_pool_migrate.go
+++ b/google/resource_container_node_pool_migrate.go
@@ -3,7 +3,7 @@ package google
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 func resourceContainerNodePoolMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {

--- a/google/resource_container_registry.go
+++ b/google/resource_container_registry.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_data_catalog_entry.go
+++ b/google/resource_data_catalog_entry.go
@@ -17,7 +17,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_data_catalog_entry_group.go
+++ b/google/resource_data_catalog_entry_group.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_data_catalog_entry_group_sweeper_test.go
+++ b/google/resource_data_catalog_entry_group_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_data_catalog_entry_sweeper_test.go
+++ b/google/resource_data_catalog_entry_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_data_catalog_tag.go
+++ b/google/resource_data_catalog_tag.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_data_catalog_tag_sweeper_test.go
+++ b/google/resource_data_catalog_tag_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_data_catalog_tag_template.go
+++ b/google/resource_data_catalog_tag_template.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_data_fusion_instance.go
+++ b/google/resource_data_fusion_instance.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_data_fusion_instance_sweeper_test.go
+++ b/google/resource_data_fusion_instance_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_data_loss_prevention_deidentify_template.go
+++ b/google/resource_data_loss_prevention_deidentify_template.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_data_loss_prevention_deidentify_template_sweeper_test.go
+++ b/google/resource_data_loss_prevention_deidentify_template_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_data_loss_prevention_inspect_template.go
+++ b/google/resource_data_loss_prevention_inspect_template.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_data_loss_prevention_inspect_template_sweeper_test.go
+++ b/google/resource_data_loss_prevention_inspect_template_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_data_loss_prevention_job_trigger.go
+++ b/google/resource_data_loss_prevention_job_trigger.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_data_loss_prevention_job_trigger_sweeper_test.go
+++ b/google/resource_data_loss_prevention_job_trigger_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_data_loss_prevention_stored_info_type.go
+++ b/google/resource_data_loss_prevention_stored_info_type.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_data_loss_prevention_stored_info_type_sweeper_test.go
+++ b/google/resource_data_loss_prevention_stored_info_type_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_dataflow_job.go
+++ b/google/resource_dataflow_job.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google/resource_dataplex_asset.go
+++ b/google/resource_dataplex_asset.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_dataplex_lake.go
+++ b/google/resource_dataplex_lake.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_dataplex_lake_sweeper_test.go
+++ b/google/resource_dataplex_lake_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	dataplex "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/dataplex"

--- a/google/resource_dataplex_zone.go
+++ b/google/resource_dataplex_zone.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_dataproc_autoscaling_policy.go
+++ b/google/resource_dataproc_autoscaling_policy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_dataproc_autoscaling_policy_sweeper_test.go
+++ b/google/resource_dataproc_autoscaling_policy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_dataproc_cluster.go
+++ b/google/resource_dataproc_cluster.go
@@ -3,7 +3,7 @@ package google
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strconv"
 	"strings"

--- a/google/resource_dataproc_job.go
+++ b/google/resource_dataproc_job.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google/resource_dataproc_job_test.go
+++ b/google/resource_dataproc_job_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 	"time"

--- a/google/resource_dataproc_metastore_service.go
+++ b/google/resource_dataproc_metastore_service.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_dataproc_metastore_service_sweeper_test.go
+++ b/google/resource_dataproc_metastore_service_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_dataproc_workflow_template.go
+++ b/google/resource_dataproc_workflow_template.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_dataproc_workflow_template_sweeper_test.go
+++ b/google/resource_dataproc_workflow_template_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	dataproc "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/dataproc"

--- a/google/resource_datastore_index.go
+++ b/google/resource_datastore_index.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_datastream_connection_profile.go
+++ b/google/resource_datastream_connection_profile.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_datastream_connection_profile_sweeper_test.go
+++ b/google/resource_datastream_connection_profile_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_datastream_private_connection.go
+++ b/google/resource_datastream_private_connection.go
@@ -17,7 +17,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_datastream_private_connection_sweeper_test.go
+++ b/google/resource_datastream_private_connection_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_datastream_stream.go
+++ b/google/resource_datastream_stream.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_datastream_stream_sweeper_test.go
+++ b/google/resource_datastream_stream_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_deployment_manager_deployment.go
+++ b/google/resource_deployment_manager_deployment.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_deployment_manager_deployment_sweeper_test.go
+++ b/google/resource_deployment_manager_deployment_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_dialogflow_agent.go
+++ b/google/resource_dialogflow_agent.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_dialogflow_cx_agent.go
+++ b/google/resource_dialogflow_cx_agent.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_dialogflow_cx_entity_type.go
+++ b/google/resource_dialogflow_cx_entity_type.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_dialogflow_cx_environment.go
+++ b/google/resource_dialogflow_cx_environment.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_dialogflow_cx_flow.go
+++ b/google/resource_dialogflow_cx_flow.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_dialogflow_cx_intent.go
+++ b/google/resource_dialogflow_cx_intent.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_dialogflow_cx_page.go
+++ b/google/resource_dialogflow_cx_page.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_dialogflow_cx_version.go
+++ b/google/resource_dialogflow_cx_version.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_dialogflow_cx_webhook.go
+++ b/google/resource_dialogflow_cx_webhook.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_dialogflow_entity_type.go
+++ b/google/resource_dialogflow_entity_type.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_dialogflow_fulfillment.go
+++ b/google/resource_dialogflow_fulfillment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_dialogflow_intent.go
+++ b/google/resource_dialogflow_intent.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_dns_managed_zone.go
+++ b/google/resource_dns_managed_zone.go
@@ -17,7 +17,7 @@ package google
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_dns_policy.go
+++ b/google/resource_dns_policy.go
@@ -17,7 +17,7 @@ package google
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_dns_record_set.go
+++ b/google/resource_dns_record_set.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"strings"
 

--- a/google/resource_document_ai_processor.go
+++ b/google/resource_document_ai_processor.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_document_ai_processor_default_version.go
+++ b/google/resource_document_ai_processor_default_version.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_document_ai_processor_sweeper_test.go
+++ b/google/resource_document_ai_processor_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_endpoints_service.go
+++ b/google/resource_endpoints_service.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strconv"
 	"strings"

--- a/google/resource_endpoints_service_migration.go
+++ b/google/resource_endpoints_service_migration.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"log"
+	log "github.com/sirupsen/logrus"
 )
 
 func migrateEndpointsService(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {

--- a/google/resource_essential_contacts_contact.go
+++ b/google/resource_essential_contacts_contact.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_essential_contacts_contact_sweeper_test.go
+++ b/google/resource_essential_contacts_contact_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_eventarc_channel.go
+++ b/google/resource_eventarc_channel.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_eventarc_channel_sweeper_test.go
+++ b/google/resource_eventarc_channel_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	eventarc "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/eventarc"

--- a/google/resource_eventarc_google_channel_config.go
+++ b/google/resource_eventarc_google_channel_config.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_eventarc_trigger.go
+++ b/google/resource_eventarc_trigger.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_eventarc_trigger_sweeper_test.go
+++ b/google/resource_eventarc_trigger_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	eventarc "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/eventarc"

--- a/google/resource_filestore_backup.go
+++ b/google/resource_filestore_backup.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_filestore_backup_sweeper_test.go
+++ b/google/resource_filestore_backup_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_filestore_instance.go
+++ b/google/resource_filestore_instance.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_filestore_instance_sweeper_test.go
+++ b/google/resource_filestore_instance_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_filestore_snapshot.go
+++ b/google/resource_filestore_snapshot.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_filestore_snapshot_sweeper_test.go
+++ b/google/resource_filestore_snapshot_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_firebase_android_app_sweeper_test.go
+++ b/google/resource_firebase_android_app_sweeper_test.go
@@ -8,7 +8,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_firebase_apple_app_sweeper_test.go
+++ b/google/resource_firebase_apple_app_sweeper_test.go
@@ -8,7 +8,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_firebase_web_app_sweeper_test.go
+++ b/google/resource_firebase_web_app_sweeper_test.go
@@ -8,7 +8,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_firebaserules_release.go
+++ b/google/resource_firebaserules_release.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_firebaserules_release_sweeper_test.go
+++ b/google/resource_firebaserules_release_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	firebaserules "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/firebaserules"

--- a/google/resource_firebaserules_ruleset.go
+++ b/google/resource_firebaserules_ruleset.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_firebaserules_ruleset_sweeper_test.go
+++ b/google/resource_firebaserules_ruleset_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	firebaserules "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/firebaserules"

--- a/google/resource_firestore_document.go
+++ b/google/resource_firestore_document.go
@@ -17,7 +17,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"

--- a/google/resource_firestore_document_sweeper_test.go
+++ b/google/resource_firestore_document_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_firestore_index.go
+++ b/google/resource_firestore_index.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_folder_access_approval_settings.go
+++ b/google/resource_folder_access_approval_settings.go
@@ -17,7 +17,7 @@ package google
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_game_services_game_server_cluster.go
+++ b/google/resource_game_services_game_server_cluster.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_game_services_game_server_cluster_sweeper_test.go
+++ b/google/resource_game_services_game_server_cluster_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_game_services_game_server_config.go
+++ b/google/resource_game_services_game_server_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_game_services_game_server_config_sweeper_test.go
+++ b/google/resource_game_services_game_server_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_game_services_game_server_deployment.go
+++ b/google/resource_game_services_game_server_deployment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_game_services_game_server_deployment_rollout.go
+++ b/google/resource_game_services_game_server_deployment_rollout.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_game_services_game_server_deployment_rollout_sweeper_test.go
+++ b/google/resource_game_services_game_server_deployment_rollout_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_game_services_game_server_deployment_sweeper_test.go
+++ b/google/resource_game_services_game_server_deployment_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_game_services_realm.go
+++ b/google/resource_game_services_realm.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_game_services_realm_sweeper_test.go
+++ b/google/resource_game_services_realm_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_gke_backup_backup_plan.go
+++ b/google/resource_gke_backup_backup_plan.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_gke_hub_membership.go
+++ b/google/resource_gke_hub_membership.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_google_project.go
+++ b/google/resource_google_project.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"regexp"
 	"strconv"

--- a/google/resource_google_project_default_service_accounts.go
+++ b/google/resource_google_project_default_service_accounts.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google/resource_google_project_migrate.go
+++ b/google/resource_google_project_migrate.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"google.golang.org/api/cloudresourcemanager/v1"

--- a/google/resource_google_project_service.go
+++ b/google/resource_google_project_service.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google/resource_google_project_test.go
+++ b/google/resource_google_project_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"reflect"
 	"strconv"

--- a/google/resource_google_service_account_key.go
+++ b/google/resource_google_service_account_key.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_google_service_networking_peered_dns_domain.go
+++ b/google/resource_google_service_networking_peered_dns_domain.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 	"time"

--- a/google/resource_healthcare_consent_store.go
+++ b/google/resource_healthcare_consent_store.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_healthcare_consent_store_sweeper_test.go
+++ b/google/resource_healthcare_consent_store_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_healthcare_dataset.go
+++ b/google/resource_healthcare_dataset.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_healthcare_dataset_sweeper_test.go
+++ b/google/resource_healthcare_dataset_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_healthcare_dicom_store.go
+++ b/google/resource_healthcare_dicom_store.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_healthcare_fhir_store.go
+++ b/google/resource_healthcare_fhir_store.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_healthcare_hl7_v2_store.go
+++ b/google/resource_healthcare_hl7_v2_store.go
@@ -17,7 +17,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_iam_access_boundary_policy.go
+++ b/google/resource_iam_access_boundary_policy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_iam_access_boundary_policy_sweeper_test.go
+++ b/google/resource_iam_access_boundary_policy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_iam_audit_config.go
+++ b/google/resource_iam_audit_config.go
@@ -3,7 +3,7 @@ package google
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_iam_binding.go
+++ b/google/resource_iam_binding.go
@@ -3,7 +3,7 @@ package google
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/davecgh/go-spew/spew"

--- a/google/resource_iam_member.go
+++ b/google/resource_iam_member.go
@@ -3,7 +3,7 @@ package google
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strings"
 

--- a/google/resource_iam_workforce_pool.go
+++ b/google/resource_iam_workforce_pool.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_iam_workforce_pool_provider.go
+++ b/google/resource_iam_workforce_pool_provider.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_iam_workforce_pool_provider_sweeper_test.go
+++ b/google/resource_iam_workforce_pool_provider_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_iam_workforce_pool_sweeper_test.go
+++ b/google/resource_iam_workforce_pool_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_iam_workload_identity_pool.go
+++ b/google/resource_iam_workload_identity_pool.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_iam_workload_identity_pool_provider.go
+++ b/google/resource_iam_workload_identity_pool_provider.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_iam_workload_identity_pool_provider_sweeper_test.go
+++ b/google/resource_iam_workload_identity_pool_provider_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_iam_workload_identity_pool_sweeper_test.go
+++ b/google/resource_iam_workload_identity_pool_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_iap_brand.go
+++ b/google/resource_iap_brand.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_iap_client.go
+++ b/google/resource_iap_client.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_identity_platform_config.go
+++ b/google/resource_identity_platform_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_identity_platform_default_supported_idp_config.go
+++ b/google/resource_identity_platform_default_supported_idp_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_identity_platform_default_supported_idp_config_sweeper_test.go
+++ b/google/resource_identity_platform_default_supported_idp_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_identity_platform_inbound_saml_config.go
+++ b/google/resource_identity_platform_inbound_saml_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_identity_platform_inbound_saml_config_sweeper_test.go
+++ b/google/resource_identity_platform_inbound_saml_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_identity_platform_oauth_idp_config.go
+++ b/google/resource_identity_platform_oauth_idp_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_identity_platform_oauth_idp_config_sweeper_test.go
+++ b/google/resource_identity_platform_oauth_idp_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_identity_platform_project_default_config.go
+++ b/google/resource_identity_platform_project_default_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_identity_platform_project_default_config_sweeper_test.go
+++ b/google/resource_identity_platform_project_default_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_identity_platform_tenant.go
+++ b/google/resource_identity_platform_tenant.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_identity_platform_tenant_default_supported_idp_config.go
+++ b/google/resource_identity_platform_tenant_default_supported_idp_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_identity_platform_tenant_inbound_saml_config.go
+++ b/google/resource_identity_platform_tenant_inbound_saml_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_identity_platform_tenant_inbound_saml_config_sweeper_test.go
+++ b/google/resource_identity_platform_tenant_inbound_saml_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_identity_platform_tenant_oauth_idp_config.go
+++ b/google/resource_identity_platform_tenant_oauth_idp_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_identity_platform_tenant_oauth_idp_config_sweeper_test.go
+++ b/google/resource_identity_platform_tenant_oauth_idp_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_identity_platform_tenant_sweeper_test.go
+++ b/google/resource_identity_platform_tenant_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_kms_crypto_key.go
+++ b/google/resource_kms_crypto_key.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_kms_crypto_key_version.go
+++ b/google/resource_kms_crypto_key_version.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_kms_key_ring.go
+++ b/google/resource_kms_key_ring.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_kms_key_ring_import_job.go
+++ b/google/resource_kms_key_ring_import_job.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_kms_key_ring_import_job_sweeper_test.go
+++ b/google/resource_kms_key_ring_import_job_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_kms_secret_ciphertext.go
+++ b/google/resource_kms_secret_ciphertext.go
@@ -17,7 +17,7 @@ package google
 import (
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"

--- a/google/resource_kms_secret_ciphertext_test.go
+++ b/google/resource_kms_secret_ciphertext_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/google/resource_logging_bucket_config.go
+++ b/google/resource_logging_bucket_config.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"strings"
 

--- a/google/resource_logging_log_view.go
+++ b/google/resource_logging_log_view.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_logging_metric.go
+++ b/google/resource_logging_metric.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_logging_metric_sweeper_test.go
+++ b/google/resource_logging_metric_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_memcache_instance.go
+++ b/google/resource_memcache_instance.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_memcache_instance_sweeper_test.go
+++ b/google/resource_memcache_instance_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_ml_engine_model.go
+++ b/google/resource_ml_engine_model.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_ml_engine_model_sweeper_test.go
+++ b/google/resource_ml_engine_model_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_monitoring_alert_policy.go
+++ b/google/resource_monitoring_alert_policy.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_monitoring_alert_policy_sweeper_test.go
+++ b/google/resource_monitoring_alert_policy_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_monitoring_alert_policy_test.go
+++ b/google/resource_monitoring_alert_policy_test.go
@@ -17,7 +17,7 @@ func TestAccMonitoringAlertPolicy(t *testing.T) {
 		"full":   testAccMonitoringAlertPolicy_full,
 		"update": testAccMonitoringAlertPolicy_update,
 		"mql":    testAccMonitoringAlertPolicy_mql,
-		"log":    testAccMonitoringAlertPolicy_log,
+		log "github.com/sirupsen/logrus":    testAccMonitoringAlertPolicy_log,
 	}
 
 	for name, tc := range testCases {
@@ -303,7 +303,7 @@ resource "google_monitoring_alert_policy" "mql" {
 
 func testAccMonitoringAlertPolicy_logCfg(alertName, conditionName string) string {
 	return fmt.Sprintf(`
-resource "google_monitoring_alert_policy" "log" {
+resource "google_monitoring_alert_policy" log "github.com/sirupsen/logrus" {
   display_name = "%s"
   combiner     = "OR"
   enabled      = true

--- a/google/resource_monitoring_custom_service.go
+++ b/google/resource_monitoring_custom_service.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_monitoring_custom_service_sweeper_test.go
+++ b/google/resource_monitoring_custom_service_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_monitoring_group.go
+++ b/google/resource_monitoring_group.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_monitoring_group_sweeper_test.go
+++ b/google/resource_monitoring_group_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_monitoring_metric_descriptor.go
+++ b/google/resource_monitoring_metric_descriptor.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_monitoring_metric_descriptor_sweeper_test.go
+++ b/google/resource_monitoring_metric_descriptor_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_monitoring_monitored_project.go
+++ b/google/resource_monitoring_monitored_project.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_monitoring_notification_channel.go
+++ b/google/resource_monitoring_notification_channel.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_monitoring_notification_channel_sweeper_test.go
+++ b/google/resource_monitoring_notification_channel_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_monitoring_service.go
+++ b/google/resource_monitoring_service.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_monitoring_service_sweeper_test.go
+++ b/google/resource_monitoring_service_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_monitoring_slo.go
+++ b/google/resource_monitoring_slo.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_monitoring_slo_sweeper_test.go
+++ b/google/resource_monitoring_slo_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_monitoring_uptime_check_config.go
+++ b/google/resource_monitoring_uptime_check_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_monitoring_uptime_check_config_sweeper_test.go
+++ b/google/resource_monitoring_uptime_check_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_network_connectivity_hub.go
+++ b/google/resource_network_connectivity_hub.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_network_connectivity_hub_sweeper_test.go
+++ b/google/resource_network_connectivity_hub_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	networkconnectivity "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/networkconnectivity"

--- a/google/resource_network_connectivity_spoke.go
+++ b/google/resource_network_connectivity_spoke.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_network_connectivity_spoke_sweeper_test.go
+++ b/google/resource_network_connectivity_spoke_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	networkconnectivity "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/networkconnectivity"

--- a/google/resource_network_management_connectivity_test_resource.go
+++ b/google/resource_network_management_connectivity_test_resource.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_network_management_connectivity_test_resource_sweeper_test.go
+++ b/google/resource_network_management_connectivity_test_resource_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_network_services_edge_cache_keyset.go
+++ b/google/resource_network_services_edge_cache_keyset.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_network_services_edge_cache_keyset_sweeper_test.go
+++ b/google/resource_network_services_edge_cache_keyset_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_network_services_edge_cache_origin.go
+++ b/google/resource_network_services_edge_cache_origin.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_network_services_edge_cache_origin_sweeper_test.go
+++ b/google/resource_network_services_edge_cache_origin_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_network_services_edge_cache_service.go
+++ b/google/resource_network_services_edge_cache_service.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_network_services_edge_cache_service_sweeper_test.go
+++ b/google/resource_network_services_edge_cache_service_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_notebooks_environment.go
+++ b/google/resource_notebooks_environment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_notebooks_environment_sweeper_test.go
+++ b/google/resource_notebooks_environment_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_notebooks_instance.go
+++ b/google/resource_notebooks_instance.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_notebooks_instance_sweeper_test.go
+++ b/google/resource_notebooks_instance_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_notebooks_location.go
+++ b/google/resource_notebooks_location.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_notebooks_location_sweeper_test.go
+++ b/google/resource_notebooks_location_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_notebooks_runtime.go
+++ b/google/resource_notebooks_runtime.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_notebooks_runtime_sweeper_test.go
+++ b/google/resource_notebooks_runtime_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_org_policy_policy.go
+++ b/google/resource_org_policy_policy.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_organization_access_approval_settings.go
+++ b/google/resource_organization_access_approval_settings.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_os_config_os_policy_assignment.go
+++ b/google/resource_os_config_os_policy_assignment.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_os_config_patch_deployment.go
+++ b/google/resource_os_config_patch_deployment.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_os_config_patch_deployment_sweeper_test.go
+++ b/google/resource_os_config_patch_deployment_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_os_login_ssh_public_key.go
+++ b/google/resource_os_login_ssh_public_key.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_os_login_ssh_public_key_sweeper_test.go
+++ b/google/resource_os_login_ssh_public_key_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_privateca_ca_pool.go
+++ b/google/resource_privateca_ca_pool.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_privateca_ca_pool_sweeper_test.go
+++ b/google/resource_privateca_ca_pool_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_privateca_certificate.go
+++ b/google/resource_privateca_certificate.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_privateca_certificate_authority.go
+++ b/google/resource_privateca_certificate_authority.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_privateca_certificate_authority_sweeper_test.go
+++ b/google/resource_privateca_certificate_authority_sweeper_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/google/resource_privateca_certificate_template.go
+++ b/google/resource_privateca_certificate_template.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_privateca_certificate_template_sweeper_test.go
+++ b/google/resource_privateca_certificate_template_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	privateca "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/privateca"

--- a/google/resource_project_access_approval_settings.go
+++ b/google/resource_project_access_approval_settings.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_pubsub_lite_reservation.go
+++ b/google/resource_pubsub_lite_reservation.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_pubsub_lite_reservation_sweeper_test.go
+++ b/google/resource_pubsub_lite_reservation_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_pubsub_lite_subscription.go
+++ b/google/resource_pubsub_lite_subscription.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_pubsub_lite_subscription_sweeper_test.go
+++ b/google/resource_pubsub_lite_subscription_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_pubsub_lite_topic.go
+++ b/google/resource_pubsub_lite_topic.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_pubsub_lite_topic_sweeper_test.go
+++ b/google/resource_pubsub_lite_topic_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_pubsub_schema.go
+++ b/google/resource_pubsub_schema.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_pubsub_schema_sweeper_test.go
+++ b/google/resource_pubsub_schema_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_pubsub_subscription.go
+++ b/google/resource_pubsub_subscription.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_pubsub_subscription_sweeper_test.go
+++ b/google/resource_pubsub_subscription_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_pubsub_topic.go
+++ b/google/resource_pubsub_topic.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_pubsub_topic_sweeper_test.go
+++ b/google/resource_pubsub_topic_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_recaptcha_enterprise_key.go
+++ b/google/resource_recaptcha_enterprise_key.go
@@ -18,7 +18,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_recaptcha_enterprise_key_sweeper_test.go
+++ b/google/resource_recaptcha_enterprise_key_sweeper_test.go
@@ -17,7 +17,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"testing"
 
 	recaptchaenterprise "github.com/GoogleCloudPlatform/declarative-resource-client-library/services/google/recaptchaenterprise"

--- a/google/resource_redis_instance.go
+++ b/google/resource_redis_instance.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strconv"

--- a/google/resource_redis_instance_sweeper_test.go
+++ b/google/resource_redis_instance_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_resource_manager_lien.go
+++ b/google/resource_resource_manager_lien.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_scc_notification_config.go
+++ b/google/resource_scc_notification_config.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_scc_notification_config_sweeper_test.go
+++ b/google/resource_scc_notification_config_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_scc_source.go
+++ b/google/resource_scc_source.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_secret_manager_secret.go
+++ b/google/resource_secret_manager_secret.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_secret_manager_secret_sweeper_test.go
+++ b/google/resource_secret_manager_secret_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_secret_manager_secret_version.go
+++ b/google/resource_secret_manager_secret_version.go
@@ -17,7 +17,7 @@ package google
 import (
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_service_networking_connection.go
+++ b/google/resource_service_networking_connection.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/url"
 	"regexp"
 	"strings"

--- a/google/resource_sourcerepo_repository.go
+++ b/google/resource_sourcerepo_repository.go
@@ -17,7 +17,7 @@ package google
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_sourcerepo_repository_sweeper_test.go
+++ b/google/resource_sourcerepo_repository_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_spanner_database.go
+++ b/google/resource_spanner_database.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strconv"

--- a/google/resource_spanner_instance.go
+++ b/google/resource_spanner_instance.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_spanner_instance_sweeper_test.go
+++ b/google/resource_spanner_instance_sweeper_test.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/google/resource_sql_database.go
+++ b/google/resource_sql_database.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_sql_database_instance.go
+++ b/google/resource_sql_database_instance.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google/resource_sql_database_instance_sweeper_test.go
+++ b/google/resource_sql_database_instance_sweeper_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google/resource_sql_source_representation_instance.go
+++ b/google/resource_sql_source_representation_instance.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strconv"
 	"strings"

--- a/google/resource_sql_source_representation_instance_sweeper_test.go
+++ b/google/resource_sql_source_representation_instance_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_sql_ssl_cert.go
+++ b/google/resource_sql_ssl_cert.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_sql_user.go
+++ b/google/resource_sql_user.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google/resource_sql_user_migrate.go
+++ b/google/resource_sql_user_migrate.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )

--- a/google/resource_storage_bucket.go
+++ b/google/resource_storage_bucket.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math"
 	"runtime"
 	"strconv"

--- a/google/resource_storage_bucket_access_control.go
+++ b/google/resource_storage_bucket_access_control.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_storage_bucket_acl.go
+++ b/google/resource_storage_bucket_acl.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 

--- a/google/resource_storage_bucket_object.go
+++ b/google/resource_storage_bucket_object.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 	"time"

--- a/google/resource_storage_bucket_sweeper_test.go
+++ b/google/resource_storage_bucket_sweeper_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/google/resource_storage_bucket_test.go
+++ b/google/resource_storage_bucket_test.go
@@ -3,7 +3,7 @@ package google
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"regexp"
 	"testing"
 	"time"

--- a/google/resource_storage_default_object_access_control.go
+++ b/google/resource_storage_default_object_access_control.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_storage_hmac_key.go
+++ b/google/resource_storage_hmac_key.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_storage_object_access_control.go
+++ b/google/resource_storage_object_access_control.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_storage_transfer_agent_pool.go
+++ b/google/resource_storage_transfer_agent_pool.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_storage_transfer_agent_pool_sweeper_test.go
+++ b/google/resource_storage_transfer_agent_pool_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_storage_transfer_job.go
+++ b/google/resource_storage_transfer_job.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_tags_location_tag_bindings.go
+++ b/google/resource_tags_location_tag_bindings.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_tags_tag_binding.go
+++ b/google/resource_tags_tag_binding.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_tags_tag_binding_sweeper_test.go
+++ b/google/resource_tags_tag_binding_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_tags_tag_key.go
+++ b/google/resource_tags_tag_key.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_tags_tag_key_sweeper_test.go
+++ b/google/resource_tags_tag_key_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_tags_tag_value.go
+++ b/google/resource_tags_tag_value.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_tags_tag_value_sweeper_test.go
+++ b/google/resource_tags_tag_value_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_tpu_node.go
+++ b/google/resource_tpu_node.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"time"

--- a/google/resource_tpu_node_sweeper_test.go
+++ b/google/resource_tpu_node_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_usage_export_bucket.go
+++ b/google/resource_usage_export_bucket.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/resource_vertex_ai_dataset.go
+++ b/google/resource_vertex_ai_dataset.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_vertex_ai_endpoint.go
+++ b/google/resource_vertex_ai_endpoint.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_vertex_ai_endpoint_sweeper_test.go
+++ b/google/resource_vertex_ai_endpoint_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_vertex_ai_featurestore.go
+++ b/google/resource_vertex_ai_featurestore.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_vertex_ai_featurestore_entitytype.go
+++ b/google/resource_vertex_ai_featurestore_entitytype.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_vertex_ai_featurestore_entitytype_feature.go
+++ b/google/resource_vertex_ai_featurestore_entitytype_feature.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/google/resource_vertex_ai_index.go
+++ b/google/resource_vertex_ai_index.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_vertex_ai_index_sweeper_test.go
+++ b/google/resource_vertex_ai_index_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_vertex_ai_tensorboard.go
+++ b/google/resource_vertex_ai_tensorboard.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_vpc_access_connector.go
+++ b/google/resource_vpc_access_connector.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"time"
 

--- a/google/resource_vpc_access_connector_sweeper_test.go
+++ b/google/resource_vpc_access_connector_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/resource_workflows_workflow.go
+++ b/google/resource_workflows_workflow.go
@@ -17,7 +17,7 @@ package google
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/google/resource_workflows_workflow_sweeper_test.go
+++ b/google/resource_workflows_workflow_sweeper_test.go
@@ -16,7 +16,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"testing"
 

--- a/google/retry_transport.go
+++ b/google/retry_transport.go
@@ -35,7 +35,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/http/httputil"
 	"time"

--- a/google/retry_utils.go
+++ b/google/retry_utils.go
@@ -1,7 +1,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/errwrap"

--- a/google/service_usage_operation.go
+++ b/google/service_usage_operation.go
@@ -17,7 +17,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/google/serviceusage_batching.go
+++ b/google/serviceusage_batching.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/google/sql_utils.go
+++ b/google/sql_utils.go
@@ -1,7 +1,7 @@
 package google
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 
 	"github.com/hashicorp/errwrap"

--- a/google/sqladmin_operation.go
+++ b/google/sqladmin_operation.go
@@ -3,7 +3,7 @@ package google
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"time"
 
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"

--- a/google/tpgtools_utils.go
+++ b/google/tpgtools_utils.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	dcl "github.com/GoogleCloudPlatform/declarative-resource-client-library/dcl"
 	"github.com/hashicorp/errwrap"

--- a/google/utils.go
+++ b/google/utils.go
@@ -4,7 +4,7 @@ package google
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"regexp"
 	"sort"

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"flag"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"

--- a/scripts/affectedtests/affectedtests.go
+++ b/scripts/affectedtests/affectedtests.go
@@ -19,7 +19,7 @@ import (
 	"go/parser"
 	"go/token"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
Use logrus for logging instead of standard log library

[_Created by Sourcegraph batch change `admin/use-logrus-in-terraform-providers`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/use-logrus-in-terraform-providers)